### PR TITLE
Bug fix for OS X download button. Now it should redirect to a correct UR...

### DIFF
--- a/inc/dlff-new.html
+++ b/inc/dlff-new.html
@@ -21,7 +21,7 @@
           </a>
         </li>
         <li class="os_osx">
-          <a class="download-link" href="http://moztw/firefox/download/latest-osx.html">
+          <a class="download-link" href="http://moztw.org/firefox/download/latest-osx.html">
             <span class="download-content">
               <strong class="download-title">Firefox</strong>
               <span class="download-subtitle">免費下載</span>


### PR DESCRIPTION
...L for the download.

-Roger
