### PR TITLE
Adjust Download Botton

### DIFF
--- a/firefox-new/index.shtml
+++ b/firefox-new/index.shtml
@@ -128,6 +128,11 @@
   .small{
     display:none;
   }
+  @media (max-width: 907px){
+    .download-button-small {
+      top: -15px;
+    }
+  }
   @media (max-width: 760px){
     #video-player-runfield {
       width: auto;
@@ -181,7 +186,7 @@
       <h1>Firefox 功能特色</h1>
       <h4>將所有超棒之處結合在一起，讓您的瀏覽變得更好。</h4>
     </hgroup>
-    <!--#include virtual="/inc/dlff-new.html"-->
+    <!--#include virtual="/inc/dlff-new.html" -->
   </div>
 </section>
 

--- a/inc/dlff-new.html
+++ b/inc/dlff-new.html
@@ -30,6 +30,16 @@
             </span>
           </a>
         </li>
+        <li class="os_android">
+          <a class="download-link" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">
+            <span class="download-content">
+              <strong class="download-title">Firefox</strong>
+              <span class="download-subtitle">免費下載</span>
+              <span class="download-lang">正體中文 (繁體)</span>
+              <span class="download-platform">Android</span>
+            </span>
+          </a>
+        </li>
       </ul>
       <small class="download-other">
         <a href="http://www.mozilla.org/en-US/firefox/all/">系統語系</a> |


### PR DESCRIPTION
Add link to play store for android.
Move RWD download button from "top:15px" to "top:-15px" in order to
avoid overlapping.
<img src="https://s3.amazonaws.com/pushbullet-uploads/ujEuDWG4uzI-ep4bDs7hW2FBUfynISdNWKBGyqunCAPV/Screenshot_2015-01-19-21-09-49.png" height="400px" width="auto">