### PR TITLE
修正 RWD 後的選單字體大小 @ firefox-new/index.shtml

### DIFF
--- a/firefox-new/index.shtml
+++ b/firefox-new/index.shtml
@@ -152,6 +152,7 @@
       display:block;
     }
     .function-menu-btn{
+      font-size:27px;
       color:black;
     }
     .function-menu li{
@@ -195,7 +196,7 @@
     <div class="module">
       <h3>
         <a class="function-menu-btn" href="javascript: SmallMenuBar()">
-          Firefox 的特色　<i class="icon-reorder"></i>
+          Firefox 的特色 <i class="icon-reorder"></i>
         </a>
       </h3>
       <ul id="function-menu" class="function-menu hide">


### PR DESCRIPTION
如圖，螢幕大小為 320x480 時，選單會換行，不好看。
這個 PR 是修正這個問題。（修改 menu-bar-btn 的字體大小）

<img src="https://cloud.githubusercontent.com/assets/6042803/5890350/ceee4fe0-a491-11e4-8ae8-c14888605545.png" width="300px">

<img src="https://cloud.githubusercontent.com/assets/6042803/5890352/cef0c3f6-a491-11e4-8e02-8b015a6c5927.png" width="300px">
