### PR TITLE
修改首頁的下載按鈕

### DIFF
--- a/index2.shtml
+++ b/index2.shtml
@@ -30,48 +30,8 @@
         <!-- slider end -->
       </div>
     </div>
-
-    <div class="key-point-slider-download download-button">
-      <ul class="download-list" role="presentation">
-        <li class="os_windows">
-          <a class="download-link" href="/firefox/download/latest-win.html" data-direct-link="https://download.mozilla.org/?product=firefox-stub&amp;os=win&amp;lang=en-US">
-            <span class="download-content">
-              <strong class="download-title">Firefox</strong>
-              <span class="download-subtitle">免費下載</span>
-              <span class="download-lang">Chinese (Taiwan)</span>
-              <span class="download-platform">Windows</span>
-            </span>
-          </a>
-        </li>
-        <li class="os_linux">
-          <a class="download-link" href="/firefox/download/latest-linux.html" data-direct-link="https://download.mozilla.org/?product=firefox-22.0&amp;os=linux&amp;lang=en-US">
-            <span class="download-content">
-              <strong class="download-title">Firefox</strong>
-              <span class="download-subtitle">免費下載</span>
-              <span class="download-lang">Chinese (Taiwan)</span>
-              <span class="download-platform">Linux</span>
-            </span>
-          </a>
-        </li>
-        <li class="os_osx">
-          <a class="download-link" href="/firefox/download/latest-osx.html" data-direct-link="https://download.mozilla.org/?product=firefox-22.0&amp;os=osx&amp;lang=en-US">
-            <span class="download-content">
-              <strong class="download-title">Firefox</strong>
-              <span class="download-subtitle">免費下載</span>
-              <span class="download-lang">Chinese (Taiwan)</span>
-              <span class="download-platform">Mac OS X</span>
-            </span>
-          </a>
-        </li>
-        <li class="os_android">
-          <a class="download-link" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">
-            <span class="download-content">
-              <strong class="download-title"><span>Firefox</span> for Android</strong>
-              <span class="download-subtitle">Get it free on Google Play</span>
-            </span>
-          </a>
-        </li>
-      </ul>
+    <div class="key-point-slider-download">
+      <!--#include virtual="/inc/dlff-new.html" -->
     </div>
   </section>
 

--- a/index2.shtml
+++ b/index2.shtml
@@ -1,5 +1,6 @@
 <!--#include virtual="/sandstone/meta.shtml" -->
   <title>Sandstone</title>
+  <style>@media screen and (max-width: 400px){.key-point-slider-download{display:none;}}</style>
 <!--#include virtual="/inc/class_homepage.html" -->
 <!--#include virtual="/sandstone/header.shtml" -->
 


### PR DESCRIPTION
1. 修正按鈕功能
2. 手機版面時按鈕會隱藏(畫面小於 400px)
3. slider 加上超連結以導引到 /mobile (與舊首頁處理方式一致)

可以注意左下角訊息（一個滑鼠是指著 slider，一個是指著按鈕）
![2015-01-25 15 17 46](https://cloud.githubusercontent.com/assets/6042803/5890751/6601a356-a4a5-11e4-8d5f-b38f0ee39d72.png)
![2015-01-25 15 17 59](https://cloud.githubusercontent.com/assets/6042803/5890750/65fee36e-a4a5-11e4-9320-14a7e9d5dfed.png)
