### PR TITLE
webfont 的暫時替代方案

### DIFF
--- a/index.shtml
+++ b/index.shtml
@@ -13,7 +13,7 @@
 }
 
 .front-feature #mobile_link {
-    background: url("/images/firefox_mobile14_trans_notxt.png") no-repeat scroll 8px 5px transparent;
+    background: url("/images/firefox_mobile14_trans.png") no-repeat scroll 8px 5px transparent;
     color: #FFFFFF;
     display: block;
     font-family: "DFHei Std", "DFLiHei Std","Heiti TC", "华文细黑", "Microsoft JhengHei", sans-serif;


### PR DESCRIPTION
webfont 掛掉了， 先換回 firefox_mobile14_trans.png
![2015-02-11 18 38 48](https://cloud.githubusercontent.com/assets/6042803/6145491/40236ea0-b21d-11e4-92f5-52ff9a387786.png)

