### PR TITLE
firefox/release → sanstone

### DIFF
--- a/firefox/releases/index2.shtml
+++ b/firefox/releases/index2.shtml
@@ -1,0 +1,581 @@
+<!--#include virtual="/sandstone/meta.shtml" -->
+<title>Mozilla Firefox 版本資訊</title>
+<style type="text/css">
+#main-version hgroup {
+    float: left;
+    margin-left: 24px;
+    margin-bottom: 1em;
+}
+#main-version hgroup h1 {
+    margin-bottom: 0.5em;
+}
+#main-version hgroup h4 {
+    margin-bottom: 0;
+}
+#main-version hgroup p {
+    margin: 0.5em 0;
+}
+.download-button-small {
+    position: relative;
+    float: right;
+    top: 15px;
+}
+.download-button-small .download-link .download-content{
+    background-image: url(/sandstone/images/firefox-small.png);
+    background-position: left center;
+    margin-left: -30px;
+    padding: 10px 20px 10px 83px;
+}
+.download-button-small .download-link .download-lang{
+    top: 22px;
+}
+nav.menu-bar {
+    clear: both;
+    text-align: center;
+}
+nav.menu-bar icon {
+    display: none;
+}
+nav.menu-bar ul {
+    margin: 0;
+}
+nav.menu-bar ul li {
+    display: inline-block;
+}
+nav.menu-bar ul li:first-child a {
+    border-left: 0;
+}
+nav.menu-bar ul li a {
+    display: inline-block;
+    padding: 6px 40px;
+    @media (max-width: 607px){
+        border-left: 1px dotted #d6d6d6;
+    }
+    padding: 6px 40px;
+}
+nav.menu-bar ul li a span {
+    display: block;
+}
+.container {
+    max-width: 990px;
+    width: auto;
+}
+.versions-top-link {
+    background: url(images/return-to-top.png) no-repeat scroll left bottom transparent;
+    float: right;
+    padding-left: 25px;
+}
+.versions-container {
+    clear: both;
+    overflow: hidden;
+}
+.versions-container h2 {
+    font-size: 48px;
+    margin-bottom: 0.5em;
+}
+.versions-container h3 {
+    font-size: 32px;
+    margin-bottom: 0.5em;
+}
+.versions-container p {
+    margin-bottom: 24px;
+}
+.versions-container hr {
+    clear: both;
+    margin: 3em -2em;
+    border: 0;
+    border-bottom: 1px dotted #d6d6d6;
+}
+.version h4 {
+    margin-bottom: 1em;
+}
+.version img {
+    float: right;
+    margin-left: 20px;
+}
+.column1 {
+    clear: left;
+}
+.column1, .column2, .column3 {
+    float: left;
+    display: inline;
+    width: 272px;
+    margin-right: 24px;
+    margin-bottom: 24px;
+}
+.column1 img, .column2 img, .column3 img {
+    margin: 0 0 25px;
+    width: 100%;
+}
+#video-wrapper {
+    float: right;
+    display: inline;
+}
+#video-wrapper p {
+    margin-top: 1em;
+}
+#video-player-runfield {
+    width: 640px;
+}
+.mozilla-video-shadow {
+    background-image: url(images/video/shadow.png);
+    background-repeat: no-repeat;
+    background-position: 50% 100%;
+    background-size: 100% 15px;
+    padding-bottom: 15px;
+}
+#highperformance .column1 {
+    width: 245px;
+}
+ul.compact {
+    padding: 0;
+}
+ul.compact li{
+    list-style-type:none;
+}
+
+
+#firefox-notes .tag {
+    background: url(/firefox/images/tags.png) no-repeat scroll 0 50% #999999;
+    border-bottom-left-radius: 2px;
+    border-top-left-radius: 2px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1), 0 -1px 0 rgba(0, 0, 0, 0.2) inset;
+    color: #383838;
+    display: inline-block;
+    font-family: "Open Sans",sans-serif;
+    font-size: 11px;
+    font-style: normal;
+    line-height: 22px;
+    min-width: 85px;
+    padding: 0 15px 0 20px;
+    text-align: right;
+    text-shadow: 1px 1px 0 #FFFFFF;
+    text-transform: uppercase;
+    width: 85px;
+}
+
+#firefox-notes .tag-new {
+    background-color: #FFEDCF;
+}
+
+#firefox-notes .tag-html5 {
+    background-color: #F8DFD8;
+    background-position: -450px 50%;
+}
+
+#firefox-notes .tag-developer {
+    background-color: #E7E7E7;
+    background-position: -900px 50%;
+}
+
+#firefox-notes .tag-changed {
+    background-color: #E9CFFF;
+    background-position: -150px 50%;
+}
+
+#firefox-notes .tag-fixed {
+    background-color: #F0FFE1;
+    background-position: -300px 50%;
+}
+
+#firefox-notes .tag-unresolved {
+    background-color: #FFC8C8;
+    background-position: -750px 50%;
+}
+
+#firefox-notes .status {
+    background: none repeat scroll 0 0 #E9F2FF;
+    border-radius: 3px 3px 3px 3px;
+    color: #383838;
+    font-family: "Open Sans",sans-serif;
+    font-size: 11px;
+    font-style: normal;
+    padding: 1px 6px;
+}
+
+#firefox-notes .status .status-unresolved, #firefox-notes .status .status-resolved {
+    background: url(/firefox/images/status-icons.png) no-repeat scroll 0 4px transparent;
+    display: inline-block;
+    margin-right: 1em;
+    padding: 2px 2px 2px 16px;
+}
+
+#firefox-notes .status .status-resolved {
+    background-position: 0 -46px;
+}
+
+#firefox-notes ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#firefox-notes ul li {
+    line-height: 2em;
+}
+
+#firefox-notes ul span {
+    font: normal 16px "Open Sans",sans-serif;
+    margin: 1em;
+    text-shadow: 0 1px 2px #FFFFFF;
+}
+
+@media (max-width: 907px){
+    .download-button-small {
+        top: -15px;
+    }
+}
+@media (max-width: 760px){
+    #video-player-runfield {
+        width: auto;
+    }
+    #video-wrapper{
+        float: none;
+    }
+    #audio, canvas, video{
+        max-width: 100%;
+    }
+}
+@media (max-width: 613px){
+    nav.menu-bar div{
+        font-size:27px;
+        color:black;
+        margin: 0;
+    }
+    nav.menu-bar div icon {
+        font-size:27px;
+        display: block;
+    }
+    nav.menu-bar ul {
+        display: none;
+    }
+    nav.menu-bar:hover ul{
+        display: block;
+    }
+    nav.menu-bar div li{
+        font-size: .75em;
+        width:100%;
+        position:relative;
+        padding: .25em 0;
+    }
+    nav.menu-bar > ul > li > a{
+        border-left-color:white;
+    }
+    nav.menu-bar > div > ul > li > a span{
+        display: inline;
+    }
+    .version img {
+        float: none;
+        margin-left: 0;
+        width: 100%;
+    }
+    .column1, .column2, .column3{
+        float: none;
+        width: 100%;
+    }
+    ul.compact,ul.compact ul {
+        padding-left: 0;
+    }
+}
+
+</style>
+<!--#include virtual="/sandstone/iefix.shtml" -->
+<!--#include virtual="/inc/class.html" -->
+<!--#include virtual="/sandstone/header.shtml" -->
+
+<section id="main-version" class="container block">
+    <div id="product-side row">
+        <hgroup id="product-desc" class="stacked">
+            <h1>Firefox 版本資訊</h1>
+            <h4 id="release-date">
+                <time datetime="2015-03-06">2015 年 3 月 6 日</time>
+                v.36.0.1
+            </h4>
+            <p>此版本資訊包含了 <a href="#whatsnew">Firefox 新鮮事</a>、<a href="#knownissues">已知問題</a>、<a href="#downloadandinstall">下載安裝指示</a>、以及<a href="#FAQ">常見問題</a>等訊息。</p>
+
+            <p>我們想知道您對 Firefox 的想法。</p>
+
+            <p>歡迎到 MozillaZine 上的<a href="http://forums.mozillazine.org/viewforum.php?f=49">英文討論區</a>或 MozTW 的 <a href="http://forum.moztw.org/viewforum.php?f=2">Firefox 中文討論區</a>與我們分享意見。</p>
+
+        </hgroup>
+        <!--#include virtual="/inc/dlff-new.html" -->
+    </div>
+
+</section>
+
+<nav class="menu-bar container block">
+    <div class="container block">
+        <icon class="module">
+            What's news <i class="icon-reorder"></i>
+        </icon>
+        <ul class="module">
+            <li><a href="/firefox/">回到 <span> Firefox 首頁 </span></a></li>
+            <li><a href="#downloadandinstall">下載<span>安裝</span></a></li>
+            <li><a href="#knownissues">已知<span>問題</span></a></li>
+            <li><a href="#troubleshooting">疑難<span>排解</span></a></li>
+            <li><a href="#FAQ">常見<span>問題</span></a></li>
+            <li><a href="#contributedbuilds">非官方<span>建製版</span></a></li>
+            <li><a href="#links">其他資源<span>連結</span></a></li>
+
+        </ul>
+    </div>
+</nav>
+
+<div id="firefox-notes" class="content container block">
+    <section id="whatsnew" class="container block">
+        <div class="versions-container module wider">
+            <a href="#main-version" class="versions-top-link">回到頂端</a>
+
+            <h2>Firefox 新鮮事</h2>
+
+            <div class="section-contents">
+                <ul>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 進行 DNS 查詢時，不再使用「ANY」查詢類型（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1093983">bug 1093983</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 修正 EMET 造成的啟動時當機情形（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1137050">bug 1137050</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 修正需重新啟動才能啟用 Hello 的情形（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1137469">bug 1137469</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 修正列印選項無法保留的問題（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1136855">bug 1136855</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 修正看不見 Hello 聯絡人分頁的問題（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1137141">bug 1137141</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 接受含有底線（<code>_</code>）的 hostname（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1136616">bug 1136616</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 修正 WebGL Canvas2d 可能耗用大量記憶體的問題（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1137251">bug 1137251</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 復原「-remote」選項（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1080319">bug 1080319</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>36.0.1 - 修正一個啟動時的當機問題。</span>
+                    </li>
+
+                    <li>
+                        <span class="tag tag-new">全新功能</span>
+                        <span>「新分頁」頁面的釘選磚塊也能同步。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-new">全新功能</span>
+                        <span>完整支援 HTTP/2 協定，帶來更具速度、擴展性及響應性的網路。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-new">全新功能</span>
+                        <span>新增烏茲別克語（Uzbek , uz）語系支援。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-changed">變更</span>
+                        <span>移除 <a href="https://developer.mozilla.org/docs/Mozilla/Command_Line_Options#-remote_remote_command"><code>-remote</code> 選項</a>。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-changed">變更</span>
+                        <span>儘可能拒絕有安全疑慮的 RC4 cipher。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-changed">變更</span>
+                        <span><a href="https://blog.mozilla.org/security/2015/01/28/phase-2-phasing-out-certificates-with-1024-bit-rsa-keys/">階段性廢止</a>採 1024-bit RSA 金鑰的憑證。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-changed">變更</span>
+                        <span>若在結束程式時失去回應，離開程式前會顯示程式錯誤回報員。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-changed">變更</span>
+                        <span><a href="https://blog.mozilla.org/addons/2015/01/13/compatibility-for-firefox-36/">附加元件相容性變更</a>。</span>
+                    </li>
+
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>支援 <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol">ECMAScript 6 Symbol</a> 資料型態。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>實作 CSS <a href="https://developer.mozilla.org/docs/Web/CSS/unicode-range">unicode-range</a> descriptor。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>實作 CSSOM-View 捲軸行為，即使不依賴客製元件庫也可以平滑捲動。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>實作 <a href="https://developer.mozilla.org/docs/Web/CSS/object-fit">object-fit</a> 和 <a href="https://developer.mozilla.org/docs/Web/CSS/object-position">object-position</a>，定義 replaced 元素的顯示方式。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>實作 CSS <a href="https://developer.mozilla.org/docs/Web/CSS/isolation">isolation</a> 屬性，允許創建新的堆疊脈絡以控制交疊物體的描繪方式。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>實作 CSS3 <a href="https://developer.mozilla.org/docs/Web/CSS/will-change">will-change</a> 屬性，用於提示將變動的元素，協助瀏覽器進行效能最佳化。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span><a href="https://wingolog.org/archives/2014/11/14/generators-in-firefox-now-twenty-two-times-faster">改善 ES6 generator</a> 以獲得更佳效能。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-html5">HTML5</span>
+                        <span>變更 JavaScript <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/const">&apos;const&apos;</a> 語義以符合 ES6 標準。新的 const 宣告將需要有 initializer、以 block 為作用範圍，且不能重複宣告。</span>
+                    </li>
+
+
+                    <li>
+                        <span class="tag tag-developer">開發功能</span>
+                        <span>除錯器可以顯示動態 <a href="https://developer.mozilla.org/docs/Tools/Debugger/How_to/Debug_eval_sources">eval 的原始碼</a>，支援傳入 eval() 的字串，或作為函數建構子的字串。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-developer">開發功能</span>
+                        <span>檢測 DOM <a href="https://developer.mozilla.org/docs/Tools/Web_Console#Type-specific_rich_output">Promise</a>。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-developer">開發功能</span>
+                        <span>檢測器：標記檢視新增了更多<a href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#Element_popup_menu">「貼上」選項</a>。</span>
+                    </li>
+
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>各種<a href="https://www.mozilla.org/security/known-vulnerabilities/firefox.html">安全性修正</a>。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>CSS <a href="https://developer.mozilla.org/docs/Web/CSS/gradient">gradient</a> 應採 premultiplied 方式處理顏色。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-fixed">修正</span>
+                        <span>修正一些重新啟動後，非預期地登出 Facebook 或 Google 的情形。</span>
+                    </li>
+
+                    <li class="complete">
+                        請參考此版本的<a href="https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&amp;f1=target_milestone&amp;o3=equals&amp;v3=Firefox%2036&amp;o1=equals&amp;resolution=FIXED&amp;o2=anyexact&amp;query_format=advanced&amp;f3=target_milestone&amp;f2=cf_status_firefox36&amp;bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;bug_status=CLOSED&amp;v1=mozilla36&amp;v2=fixed%2Cverified&amp;limit=0">完整變更清單</a>。
+
+                        您可能也想瞭解<a href="/firefox/releases/36.0/">前一個版本的更新</a>。
+                    </li>
+                </ul>
+            </div>
+
+        </div>
+    </section>
+
+    <section class="container block">
+        <div class="versions-container module wider">
+            <a href="#main-version" class="versions-top-link">回到頂端</a>
+
+            <h2 id="knownissues">已知問題</h2>
+
+            <div class="section-contents">
+                <ul>
+                    <li>
+                        <span class="tag tag-unresolved">尚未修復</span>
+                        <span>樣式編輯器：修正 sourcemap scss 檔案顯示多餘空白的問題（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1128747">bug 1128747</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-unresolved">尚未修復</span>
+                        <span>已被使用者移除的「分享此頁面」或「Hello」按鈕，可能在更新這個版本後又非預期地出現（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1136300">bug 1136300</a>）。</span>
+                    </li>
+                    <li>
+                        <span class="tag tag-unresolved">尚未修復</span>
+                        <span>未安裝攝影機時，Firefox Hello 可能無法產生對話用的鏈結（<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1106941">bug 1106941</a>）。</span>
+                    </li>
+                </ul>
+            </div>
+
+        </div>
+    </section>
+</div>
+
+<div class="content container block">
+    <section id="downloadandinstall" class="container block">
+        <div class="versions-container module wider">
+            <a href="#main-version" class="versions-top-link">回到頂端</a>
+
+            <h2>下載與安裝</h2>
+
+            <h3 id="requirements">系統需求</h3>
+            <p>在安裝 Firefox 前請先確定您的電腦是否合乎<a href="http://moztw.org/docs/fx/system-requirements/">系統需求</a>。</p>
+
+            <h3 id="download">下載 Firefox</h3>
+            <p>您可以<a href="http://moztw.org/firefox/">由此下載最新的 Firefox</a>，或取得 Windows、Linux 及 Mac OS X 平台上的<a href="http://www.mozilla.com/firefox/all.html">各國語言版本</a>，或<a href="http://www.mozilla.com/firefox/channel/">由此下載 Firefox 未來發行版本</a>（測試版）。若需自行編譯其他平台或語言的版本，請見本文件最末節。</p>
+
+            <h3 id="install">安裝 Firefox</h3>
+            <p>請注意：安裝新版 Firefox 將<em>覆蓋</em>現存的 Firefox 程式，您不會遺失書籤或瀏覽記錄，但有些附加元件可能要更新才能繼續使用。詳細安裝步驟請參見<a href="https://support.mozilla.org/zh-TW/kb/Installing%20Firefox">如何安裝 Firefox</a>。</p>
+
+            <h3 id="uninstall">移除 Firefox</h3>
+            <p>在 Windows 作業系統中，您可以使用「新增或移除程式」移除 Firefox。OS X 的使用者請將 Firefox 程式移至垃圾筒；Linux 使用者則請移除包含 Firefox 的資料夾。</p>
+            <p>一般狀況下，移除 Firefox 時不會把書籤、瀏覽記錄、擴充套件和其他附加元件一併刪除，這些資料會保留在您的「<em>個人設定資料夾</em>」內，此資料夾可以在「<span class="location-item">說明</span>」選單的「<span class="location-item">疑難排解資訊…</span>」找到，按下「<span class="location-item">應用程式一般資訊</span>」中「設定檔目錄」旁的按鈕便可開啟它。</p>
+            <p>請留意若您沒有手動刪除個人設定資料夾，移除後重新安裝 Firefox 將繼續沿用原本的設定檔。</p>
+
+            <h3 id="extensions">附加元件及佈景主題</h3>
+            <p>您可以由「附加元件管理員」或<a href="http://addons.mozilla.org">附加元件網站</a>取得附加元件及佈景主題。 當 Firefox 升級時，附加元件可能因不相容於新版 Firefox 而被停用，此時則需要原作者進行升級。若您想協助回報升級 Firefox 後功能有問題的附加元件，請<a href="https://addons.mozilla.org/firefox/addon/add-on-compatibility-reporter/">安裝 Add-on Compatibility Reporter</a> 擴充套件 —— 您喜愛的元件作者會相當感激！</p>
+
+
+        </div>
+    </section>
+</div>
+
+
+<div class="content container block">
+    <section id="troubleshooting" class="container block">
+        <div class="versions-container module wider">
+            <a href="#main-version" class="versions-top-link">回到頂端</a>
+
+            <h2>疑難排解</h2>
+            <ul class="compact">
+                <li>設計不良或不相容的套件將導致瀏覽器發生問題，包含當機或網頁瀏覽速度變慢等等狀況。如果您碰上瀏覽器無法開啟、視窗顯示不正常等等狀況，便可能是擴充套件或佈景主題的問題。這時請參考「<a href="https://support.mozilla.org/zh-TW/kb/troubleshoot-firefox-issues-using-safe-mode">Firefox 輔助說明：安全模式</a>」一文開啟 Firefox 安全模式。在安全模式下，所有附加元件及佈景主題將被停用。請您在安全模式下移除有問題的擴充套件或佈景主題，再正常地啟動瀏覽器。</li>
+                <li>如果您遇到與書籤、下載、視窗位置、工具列、瀏覽記錄或其他奇怪問題，建議您在回報問題前先建立新的使用者設定檔試試。請參考「<a href="https://support.mozilla.org/zh-TW/kb/profile-manager-create-and-remove-firefox-profiles">Firefox 輔助說明：使用設定檔管理員建立或移除 Firefox 設定檔</a>」一文建立新的使用者設定檔，並將各種設定（書籤、儲存的密碼等）從舊的設定檔中分次轉移到新的設定檔（可透過 <a href="https://support.mozilla.org/zh-TW/kb/firefox-sync-take-your-bookmarks-and-tabs-with-you">Firefox Sync 同步功能</a>進行）。</li>
+            </ul>
+            <h3 id="FAQ">常見問題集</h3>
+            <ol class="faq">
+                <li>我該怎麼幫忙呢？
+                    <p>我們需要開發員和測試社群回饋建議，幫我們將 Firefox 變得更盡善盡美。請先查閱 <a href="http://support.mozilla.org/">Firefox 輔助說明</a>看看有沒有相關解答，再到 <a href="http://bugzilla.mozilla.org/">Bugzilla</a> 回報你發現的錯誤；您也可以使用<a href="http://input.mozilla.com/zh-TW/feedback">意見回饋功能</a>表達意見。</p>
+                </li>
+                <li>我如何預覽未來的 Firefox 版本？
+                    <p>加入 <a href="http://www.mozilla.com/firefox/channel/">Aurora 或 Beta 開發頻道</a>就可以搶先試用  Firefox 開發中版本。</p>
+                </li>
+                <li>我該到哪裡才能用中文問問題跟表示意見？
+                    <p>請使用 <a href="http://forum.moztw.org/viewforum.php?f=2">Firefox 討論區</a>，MozTW 社群團隊與熱心的 Firefox 用戶會定期閱讀上面的文章。</p>
+                </li>
+                <li>我該去哪裡取得新的佈景主題與擴充功能 (附加元件)？
+                    <p>請到 <a href="https://addons.mozilla.org/firefox/">Mozilla 附加元件中心</a>下載 Firefox 的擴充套件及佈景主題。</p>
+                </li>
+                <li>Firefox 是哪些人做出來的？
+                    <p>Firefox 是由世界各地的 <a href='http://www.mozilla.org/community/'>Mozilla 社群</a>成員與員工合力開發。<a href='http://www.mozilla.org/credits/'>這裡有份長長的名單</a>，列出部分曾對 Firefox 有重要貢獻的人。<a href='http://www.mozilla.org/contribute/'>想要加入我們的大家庭嗎？</a>或者<a href="http://moztw.org/contribute/">加入 Mozilla 台灣社群？</a></p>
+                </li>
+                <li>Firefox 的原始碼在何處？
+                    <p>請參照 <a href="https://developer.mozilla.org/en-US/docs/Developer_Guide/Source_Code/Mercurial">Getting Mozilla Source Code Using Mercurial</a> 一文取得 Firefox 原始碼；如需編譯 Firefox，請參考 <a href="https://developer.mozilla.org/en-US/docs/Developer_Guide/Build_Instructions">Build Instructions</a>。</p>
+                </li>
+                <li>電子郵件程式呢？
+                    <p>Firefox 能與您預設的任何郵件程式協同運作，而我們推薦您試試我們下一代的郵件軟體：與 Firefox 合作無間的 <a href="http://moztw.org/thunderbird/">Mozilla Thunderbird</a>。</p>
+                </li>
+            </ol>
+
+            <h3 id="contributedbuilds">非官方建製版</h3>
+            <p>您可以在 MozTW 討論區的<a href="http://forum.moztw.org/viewforum.php?f=43">社群自訂版本</a>討論版找到網友自行編譯調整的非官方版 Firefox。</p>
+
+            <h3 id="links">其他資源和連結</h3>
+            <p>下面提供了幾個有用的連結：</p>
+            <ul class="compact">
+                <li><a id="oj3s" title="Mozilla Links 正體中文版" href="http://mozlinks-zh.blogspot.com/">Mozilla Links 正體中文版</a></li>
+                <li><a href="http://support.mozilla.org/zh-TW/">Firefox 技術支援</a></li>
+                <li><a href="https://developer.mozilla.org/zh-TW/">Mozilla Developer Network</a></li>
+                <li><a href="http://blog.mozilla.org/futurereleases/">Future of Firefox Blog</a></li>
+            </ul>
+
+        </div>
+    </section>
+</div>
+
+<!--#include virtual="/sandstone/footer.shtml" -->


### PR DESCRIPTION
issue #175 
製作 /firefox/release 的 sandstone 版型供未來的 /firefox/release 使用

附圖：
![2015-03-15 16 45 59](https://cloud.githubusercontent.com/assets/6042803/6655270/d9618056-cb32-11e4-99fa-289f5c919540.png)
![2015-03-15 16 46 05](https://cloud.githubusercontent.com/assets/6042803/6655267/d95cd204-cb32-11e4-9f94-ae1c98cdd14d.png)
![2015-03-15 16 46 12](https://cloud.githubusercontent.com/assets/6042803/6655268/d9611cd8-cb32-11e4-8a2a-b385f8cdebd0.png)
![2015-03-15 16 46 19](https://cloud.githubusercontent.com/assets/6042803/6655269/d9613be6-cb32-11e4-9431-a58771ec934b.png)
![2015-03-15 16 46 21](https://cloud.githubusercontent.com/assets/6042803/6655271/d968e936-cb32-11e4-805f-b567d659c705.png)

