### PR TITLE
Fix #194 /thunderbird/releases 選單順序調整

### DIFF
--- a/thunderbird/releases/index.shtml
+++ b/thunderbird/releases/index.shtml
@@ -65,8 +65,8 @@
 			<article id="nav" class="module hide-mobile">
 				<ul>
 					<li><a href="/thunderbird/">回 Thunderbird 首頁</a></li>
-					<li><a href="#downloadandinstall">下載與安裝</a></li>
 					<li><a href="#knownissues">已知問題</a></li>
+					<li><a href="#downloadandinstall">下載與安裝</a></li>
 				</ul>
 			</article>
 

--- a/thunderbird/releases/index.shtml
+++ b/thunderbird/releases/index.shtml
@@ -64,7 +64,7 @@
 		<div class="grid-3 sidebar">
 			<article id="nav" class="module hide-mobile">
 				<ul>
-					<li><a href="/thunderbird/">回 Thunderbird 首頁</a></li>
+					<li><a href="/thunderbird/">&lt; 回 Thunderbird 首頁</a></li>
 					<li><a href="#knownissues">已知問題</a></li>
 					<li><a href="#downloadandinstall">下載與安裝</a></li>
 				</ul>


### PR DESCRIPTION
選單順序調整成：
 - 回 Thunderbird 首頁
 - 已知問題
 - 下載與安裝