### PR TITLE
Modify the pattern of grunt-sitemap

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
 		},
 		sitemap: {
 			dist: {
-				pattern: ['**/*.html', '!**/google*.html'], // this will exclude 'google*.html'
+				pattern: ['**/*.html', '!**/google*.html','!**/inc/*','!**/node_modules/*','!**/sandstone/*',' !**/*-dev/*','!**/index2*'],
 				siteRoot: './',
 				homepage: "http://moztw.org/",
 			}


### PR DESCRIPTION
Add `!**/inc/*`, `!**/node_modules/*`, `!**/sandstone/*`, `!**/*-dev/*`, `!**/index2*` to avoid sitemap map theme.

// 英文不好還硬要用英文XD