### PR TITLE
於Readme新增給Ubuntu/Debian使用者的提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ You can do shallow clone to get this repo more quickly.
 
 ### Using Node.js directly
 1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system. 
-   On Windows, you also need `Microsoft Visual C++ Redistributable Package`.
-   On Ubuntu/Debian, you also need `nodejs-legacy` package.
+   * On Windows, you also need `Microsoft Visual C++ Redistributable Package`.
+   * On Ubuntu/Debian, you also need `nodejs-legacy` package.
 2. Run `npm install` in repo directory.
 3. Run `npm start` in repo directory, the output will stay at `Watching files`.
 4. Open `localhost:3000`, modify and see the [browswersync](http://browsersync.io/) result.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ You can do shallow clone to get this repo more quickly.
 
 
 ### Using Node.js directly
-1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system. (You also need `Microsoft Visual C++ Redistributable Package` on Windows)
+1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system. 
+   On Windows, you also need `Microsoft Visual C++ Redistributable Package`.
+   On Linux, you also need `nodejs-legacy` package.
 2. Run `npm install` in repo directory.
 3. Run `npm start` in repo directory, the output will stay at `Watching files`.
 4. Open `localhost:3000`, modify and see the [browswersync](http://browsersync.io/) result.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can do shallow clone to get this repo more quickly.
 ### Using Node.js directly
 1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system. 
    On Windows, you also need `Microsoft Visual C++ Redistributable Package`.
-   On Linux, you also need `nodejs-legacy` package.
+   On Ubuntu/Debian, you also need `nodejs-legacy` package.
 2. Run `npm install` in repo directory.
 3. Run `npm start` in repo directory, the output will stay at `Watching files`.
 4. Open `localhost:3000`, modify and see the [browswersync](http://browsersync.io/) result.


### PR DESCRIPTION
提示需安裝[nodejs-legacy]才能以node指令執行npm start script.