### PR TITLE
Change Webmaker url in Quick links

### DIFF
--- a/index.shtml
+++ b/index.shtml
@@ -282,7 +282,7 @@
     <ul class="news">
       <li><a href="//forum.moztw.org/viewforum.php?f=2" onClick="ga('send', 'event', 'Outgoing', 'Firefox Mozilla - Channel', 'frontpage');">Firefox 中文討論區</a></li>
       <li><a href="/events/moztw-lab/">MozTW Lab 定期聚會</a></li>
-      <li><a href="https://webmaker.org/" onClick="ga('send', 'event', 'Outgoing', 'Webmaker', 'frontpage');">Mozilla Webmaker</a></li>
+      <li><a href="https://learning.mozilla.org/" onClick="ga('send', 'event', 'Outgoing', 'Webmaker', 'frontpage');">Mozilla Webmaker</a></li>
       <li><a href="http://mozlinks.moztw.org/" onClick="ga('send', 'event', 'Outgoing', 'Mozilla Links', 'frontpage');">Mozilla Links 正體中文版</a></li>
       <li><a href="http://www.mozilla.com/zh-TW/firefox/channel/" onClick="ga('send', 'event', 'Outgoing', 'Firefox Mozilla - Channel', 'frontpage');">Firefox 未來發行版本</a></li>
       <li><a href="http://wiki.moztw.org/">共筆系統</a></li>

--- a/index2.shtml
+++ b/index2.shtml
@@ -107,7 +107,7 @@
 			<ul class="news">
 			  <li><a href="//forum.moztw.org/viewforum.php?f=2" onClick="ga('send', 'event', 'Outgoing', 'Firefox Mozilla - Channel', 'frontpage');">Firefox 中文討論區</a></li>
 			  <li><a href="/events/moztw-lab/">MozTW Lab 定期聚會</a></li>
-			  <li><a href="https://webmaker.org/" onClick="ga('send', 'event', 'Outgoing', 'Webmaker', 'frontpage');">Mozilla Webmaker</a></li>
+			  <li><a href="https://learning.mozilla.org/" onClick="ga('send', 'event', 'Outgoing', 'Webmaker', 'frontpage');">Mozilla Webmaker</a></li>
 			  <li><a href="http://mozlinks.moztw.org/" onClick="ga('send', 'event', 'Outgoing', 'Mozilla Links', 'frontpage');">Mozilla Links 正體中文版</a></li>
 			  <li><a href="http://www.mozilla.com/zh-TW/firefox/channel/" onClick="ga('send', 'event', 'Outgoing', 'Firefox Mozilla - Channel', 'frontpage');">Firefox 未來發行版本</a></li>
 			  <li><a href="http://wiki.moztw.org/">共筆系統</a></li>


### PR DESCRIPTION
https://webmaker.org/ -> https://learning.mozilla.org/
#459