### PR TITLE
remove sensor web from /space

### DIFF
--- a/space/css/mozspacetp.css
+++ b/space/css/mozspacetp.css
@@ -151,13 +151,7 @@ div[class^=grid-] {
   text-align: center;
 }
 
-#sensorweb div.grid-4{
-  text-align: center;
-}
-
 /* RWD */
-
-
 
 @media only screen and (max-width:960px) {
 

--- a/space/index.shtml
+++ b/space/index.shtml
@@ -178,24 +178,6 @@
         <a href="http://folder.moztw.org/moztw-space/https%253A%252F%252Fetherpad.mozilla.org%252Fmoztw-taipei-space-guildline">使用規範</a>
       </div>
     </section>
-
-    <section id="sensorweb" class="grids">
-      <header>
-        <div class="hgroup">
-          <h1>特別企劃：看看工寮空氣如何</h1>
-          <h2>Check the air quality in the Space</h2>
-        </div>
-      </header>
-      <div class="grid-8">
-        <p><strong>Project SensorWeb</strong> 是 Mozilla 實驗規劃中的物聯網開放資料平台，目前正在測試簡易的眾包式 PM2.5 空氣品質監測網絡，請<a href="http://sensorweb.io/">參考他們的網站</a>進一步了解這個專案。</p>
-        <p><strong>Project SensorWeb</strong> is an open data platform for IoT from Mozilla's Connected Device "Product Innovation." They are running a
-          pilot to build a crowdsourced PM2.5 air pollution sensor network on the platform.
-           <a href="http://sensorweb.io/">Check the website</a> for more information.</p>
-      </div>
-      <div class="grid-4">
-        <iframe width="125" height="125" src="https://sensorweb.io/widget.html?id=rJujLq2M" frameborder="0" scrolling="no"></iframe>
-      </div>
-    </section>
   </main>
 </div>
 


### PR DESCRIPTION
在 safari 上錯誤的 https 訊息會讓頁面跳到 sensorweb 的 iframe url 去，只好先移掉 
#522 