### PR TITLE
寫死 mozlcdb 的更新日期

### DIFF
--- a/tools/mozlcdb/index.shtml
+++ b/tools/mozlcdb/index.shtml
@@ -81,8 +81,7 @@ Get these files:
 	<li><a href='archive/mozlcdb_v0.2.zip'> Version 0.2 </a>(Stable, approved with FF1.0/TB0.8, 2004/09/27)</li>
 	<li><a href='archive/mozlcdb_v0.1.zip'> Version 0.1 </a>(Deprecated)</li>
 	</ul>
-	<li style='padding-top: 10px;'>Latest beta: <ul><li><a href='archive/mozlcdb_latest.zip'>
-		<!--#flastmod virtual="archive/mozlcdb_latest.zip" --> </a> (hack on your own!)</li>
+	<li style='padding-top: 10px;'>Latest beta: <ul><li><a href='archive/mozlcdb_latest.zip'> 2009/9/27 </a> (hack on your own!)</li>
 	</ul>
     </ul>
 </ul>


### PR DESCRIPTION
這工具看起來已經沒有在更新了，應該可以將更新日期寫死
這樣生成網頁就不需要用到 flastmod

日期來自：https://github.com/moztw/www.moztw.org/blob/5801223684f1622ee1a81251cdc14e939e02af28/tools/mozlcdb/archive/mozlcdb_latest.zip