### PR TITLE
修正SSI設定問題 與 Thunderbird載點版號更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ The second step is adding virtual host configs to your Apache configuration:
   DocumentRoot /path/to/this/repo/
   <Directory /path/to/this/repo>
     Options FollowSymLinks Includes
-    DirectoryIndex index.shtml
-    SSILegacyExprParser on
+    SSILegacyExprParse on
     AllowOverride All
     Order allow,deny
     Require all granted

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ please fork and checkout as you need.
 
     base - Server configurations and automatic scripts
     www.moztw.org - Main MozTW website
-    forum.moztw.org - MozTW Forum    
+    forum.moztw.org - MozTW Forum
     irclog.moztw.org - Log Archive for #mozilla-taiwan on irc.mozilla.org and #moztw on Telegram.
     translate.moztw.org - Localization system related stuff
     planet.moztw.org - A Planetplanet installation for MozTW Planet http://planet.moztw.org/
@@ -56,7 +56,7 @@ You can do shallow clone to get this repo more quickly.
    Also if you want to stop the virtual machine running, run `vagrant halt`.
 
 ### Using Node.js directly
-1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system. 
+1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system.
    * On Windows, you also need `Microsoft Visual C++ Redistributable Package`.
    * On Ubuntu/Debian, you also need `nodejs-legacy` package.
 2. Run `npm install` in repo directory.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The second step is adding virtual host configs to your Apache configuration:
   DocumentRoot /path/to/this/repo/
   <Directory /path/to/this/repo>
     Options FollowSymLinks Includes
-    SSILegacyExprParse on
+    SSILegacyExprParser on
     AllowOverride All
     Order allow,deny
     Require all granted

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ The second step is adding virtual host configs to your Apache configuration:
   DocumentRoot /path/to/this/repo/
   <Directory /path/to/this/repo>
     Options FollowSymLinks Includes
-    SSILegacyExprParse on
+    DirectoryIndex index.shtml
+    SSILegacyExprParser on
     AllowOverride All
     Order allow,deny
     Require all granted

--- a/inc/dltb2.shtml
+++ b/inc/dltb2.shtml
@@ -1,6 +1,6 @@
-<!--#set var="WINVER" value="52.6.0" -->
-<!--#set var="LINUXVER" value="52.6.0" -->
-<!--#set var="OSXVER" value="52.6.0" -->
+<!--#set var="WINVER" value="60.4.0" -->
+<!--#set var="LINUXVER" value="60.4.0" -->
+<!--#set var="OSXVER" value="60.4.0" -->
 
 <!--#set var="WINTAG" value="${WINVER}-Windows" -->
 <!--#set var="LINUXTAG" value="${LINUXVER}-Linux" -->

--- a/index.shtml
+++ b/index.shtml
@@ -231,7 +231,7 @@
         <!--#if expr="" -->
         <!-- point to .shtml while test locally -->
         <!--#endif -->
-        <!--#include virtual="/inc/dlff.html" -->
+        <!--#include virtual="/inc/dlff.shtml" -->
       </div>
     </div>
     <div class="download dl-mobile" onclick="">

--- a/index.shtml
+++ b/index.shtml
@@ -231,7 +231,7 @@
         <!--#if expr="" -->
         <!-- point to .shtml while test locally -->
         <!--#endif -->
-        <!--#include virtual="/inc/dlff.shtml" -->
+        <!--#include virtual="/inc/dlff.html" -->
       </div>
     </div>
     <div class="download dl-mobile" onclick="">


### PR DESCRIPTION
後來發現應該是 `README.md` 文件的語法打錯，是 `SSILegacyExprParser on` ，不是 `SSILegacyExprParse on` （少了 `r` 字），也順便處理行末多餘空隔。

然後 `/index.shtml` 那邊第234行的下載Firefox那邊也有錯。
是 `<!--#include virtual="/inc/dlff.shtml" -->`
不是 `<!--#include virtual="/inc/dlff.html" -->` （少了 `s` 字）