### PR TITLE
Fix Foxmosa Telegram sticker link

### DIFF
--- a/community/telegram/index.shtml
+++ b/community/telegram/index.shtml
@@ -66,7 +66,7 @@
 
     <!-- Public to bots -->
     <div id="sticker">
-        <a href="https://telegram.me/addstickers/Foxmosa" target="_blank">
+        <a href="https://telegram.me/addstickers/FoxmosaTW" target="_blank">
             <span lang="zh-tw" title="Foxmosa Telegram 貼圖">Foxmosa 貼圖</span>
             <span lang="en" title="Foxmosa Telegram Sticker">Foxmosa Stickers</span>
         </a>


### PR DESCRIPTION
The original one cannot be found on Telegram, new one is FoxmosaTW.