### PR TITLE
fix(bs): replace all dlff.html to dlff.shtml

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ You can do shallow clone to get this repo more quickly.
 -->
 
 ### Using Node.js directly
-0. You will need to [modify index.shtml](https://github.com/moztw/www.moztw.org/blob/2296093f518003b18fb355178161f09222c206f3/index.shtml#L235), change `dlff.html` to dlff.**s**html for web server to work.
 1. Install [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/) in your system.
    * On Windows, you also need `Microsoft Visual C++ Redistributable Package`.
    * On Ubuntu/Debian, you also need `nodejs-legacy` package.
 2. Run `npm install` in repo directory.
 3. Run `npm start` in repo directory, the output will stay at `Watching files`.
-4. Open `localhost:3000`, modify html and [browswersync](http://browsersync.io/) will reload the preview page.
+4. Open `localhost:3000`, modify html and [browsersync](http://browsersync.io/) will reload the preview page.
 
 
 ## Static Pages Local Installation

--- a/bs-config.js
+++ b/bs-config.js
@@ -30,10 +30,19 @@ module.exports = {
     var pathname = require('url').parse(req.originalUrl || req.url).pathname;
     var filename = require('path').join(baseDir, pathname.substr(-1) === '/' ? pathname + 'index.shtml' : pathname);
     var parser = new ssi(baseDir, baseDir, '/**/*.shtml');
+    
+    // HTML content.
+    var content = fs.readFileSync(filename, {
+      encoding: 'utf8'
+    });
+
+    content = content.replace(
+      '<!--#include virtual="/inc/dlff.html" -->',
+      '<!--#include virtual="/inc/dlff.shtml" -->',
+    );
+    
     if (filename.indexOf('.shtml') > -1 && fs.existsSync(filename))
-      res.end(parser.parse(filename, fs.readFileSync(filename, {
-        encoding: 'utf8'
-      })).contents);
+      res.end(parser.parse(filename, content).contents);
     else
       next();
   }]


### PR DESCRIPTION
本地開發環境的 `dlff.shtml` 即生產環境的 `dlff.html`，但 browser-sync 由於先前不會自動替換相關檔名，導致乾淨環境執行 `npm run start` 時會拋出「找不到 `dlff.html`」的錯誤。本 PR 透過在 browser-sync 的 Middleware，加上 replace 檔名的 statement 來解決此問題。

註：本 PR 由於只在 `npm run start` 時動態修改檔案內容，不會影響生產環境的運作。
