### PR TITLE
fix(index): url is always empty

### DIFF
--- a/index.shtml
+++ b/index.shtml
@@ -341,7 +341,6 @@ $(function () {
       var title = val.title.substring(author.length + 2);
       if (title > 100) title = title.substring(0, 100) + "……"; // 超過 100 個字就截斷並加上 '……'
       var url = val.link;
-      url = url.substring(0, url.indexOf('?source'));
 
       $rssList.append('<li><a href="' + url + '">' + title + '</a> &ndash; ' + author + '</li>');
     });


### PR DESCRIPTION
以前的 API 似乎每個連結後面都有 `?source` 的追蹤字串，而新的 API 已經不會有這個標記了。

然而目前的程式碼未事先檢查連結是否有 `?source`，導致沒有這個字串時，.substring() 永遠回傳空字串。

對使用者來講，最直觀的感受就是連結點不開。因此我直接把這個可能已經用不到的 dead code 刪除，來解決這個問題。

Fixed #686
