### PR TITLE
fix(lint-version-metadata): Throttle and timeout

### DIFF
--- a/tools/get-stable-version.ts
+++ b/tools/get-stable-version.ts
@@ -40,12 +40,12 @@ const [fxLatestVer, tbLatestVer] = await Promise.all(
     return deserializedResponse[
       id === "fx" ? "LATEST_FIREFOX_VERSION" : "LATEST_THUNDERBIRD_VERSION"
     ];
-  })
+  }),
 );
 
 console.log(
-  `The latest stable version of \x1b[1;33mFirefox\x1b[0m is \x1b[1m${fxLatestVer}\x1b[0m.`
+  `The latest stable version of \x1b[1;33mFirefox\x1b[0m is \x1b[1m${fxLatestVer}\x1b[0m.`,
 );
 console.log(
-  `The latest stable version of \x1b[1;34mThunderbird\x1b[0m is \x1b[1m${tbLatestVer}\x1b[0m.`
+  `The latest stable version of \x1b[1;34mThunderbird\x1b[0m is \x1b[1m${tbLatestVer}\x1b[0m.`,
 );


### PR DESCRIPTION
This script may be stuck on some environments. Therefore, this commit:

- Limit the allowing concurrent requests  to at most 3.
- Abort the request after 5 seconds.

Besides, this commit also formats the code.
